### PR TITLE
Update for Logstash 5 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,15 @@
-# 1.0.0
+## 1.1.0
+- Logstash 5 compatibility
 
-- Initial Release
-
-# 1.0.1
-
-- same (because of screwed up rubygems.org release)
-
-# 1.0.2
-
-- fix for broken UTF-8 (so we won't lose a whole s3 log file because of a single invalid line, ruby's split will die on those)
-
-# 1.0.3
-
+## 1.0.3
 - added some metadata to the event (bucket and object name as commited by joshuaspence)
 - also try to unzip files ending with ".gz" (ALB logs are zipped but not marked with proper Content-Encoding)
+
+## 1.0.2
+- fix for broken UTF-8 (so we won't lose a whole s3 log file because of a single invalid line, ruby's split will die on those)
+
+## 1.0.1
+- same (because of screwed up rubygems.org release)
+
+## 1.0.0
+- Initial Release

--- a/lib/logstash/inputs/s3sqs.rb
+++ b/lib/logstash/inputs/s3sqs.rb
@@ -159,8 +159,8 @@ class LogStash::Inputs::S3SQS < LogStash::Inputs::Threadable
                 @codec.decode(line) do |event|
                   decorate(event)
 
-                  event['[@metadata][s3_bucket_name]'] = record['s3']['bucket']['name']
-                  event['[@metadata][s3_object_key]']  = record['s3']['object']['key']
+                  event.set('[@metadata][s3_bucket_name]', record['s3']['bucket']['name'])
+                  event.set('[@metadata][s3_object_key]', record['s3']['object']['key'])
 
                   queue << event
                 end

--- a/logstash-input-s3sqs.gemspec
+++ b/logstash-input-s3sqs.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-input-s3sqs'
-  s.version         = '1.0.4'
+  s.version         = '1.1.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Get logs from AWS s3 buckets as issued by an object-created event via sqs."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "input" }
 
   # Gem dependencies
-  s.add_runtime_dependency "logstash-core-plugin-api", "~> 1.0"
+  s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
 
   s.add_runtime_dependency 'logstash-codec-json'
   s.add_runtime_dependency "logstash-mixin-aws", ">= 1.0.0"


### PR DESCRIPTION
Updates the plugin to use the new `Event` API for Logstash 5 compatibility.