### PR TITLE
Add the ability to delete objects from S3 after processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.1
+- Added the ability to remove objects from S3 after processing.
+- Workaround an issue with the Ruby autoload that causes "uninitialized constant `Aws::Client::Errors`" errors.
+
 ## 1.1.0
 - Logstash 5 compatibility
 

--- a/lib/logstash/inputs/s3sqs/patch.rb
+++ b/lib/logstash/inputs/s3sqs/patch.rb
@@ -1,0 +1,22 @@
+# This patch was stolen from logstash-plugins/logstash-output-s3#102.
+#
+# This patch is a workaround for a JRuby issue which has been fixed in JRuby
+# 9000, but not in JRuby 1.7. See https://github.com/jruby/jruby/issues/3645
+# and https://github.com/jruby/jruby/issues/3920. This is necessary because the
+# `aws-sdk` is doing tricky name discovery to generate the correct error class.
+#
+# As per https://github.com/aws/aws-sdk-ruby/issues/1301#issuecomment-261115960,
+# this patch may be short-lived anyway.
+require 'aws-sdk'
+
+begin
+  old_stderr = $stderr
+  $stderr = StringIO.new
+
+  module Aws
+    const_set(:S3, Aws::S3)
+    const_set(:SQS, Aws::SQS)
+  end
+ensure
+  $stderr = old_stderr
+end

--- a/logstash-input-s3sqs.gemspec
+++ b/logstash-input-s3sqs.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-input-s3sqs'
-  s.version         = '1.1.0'
+  s.version         = '1.1.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Get logs from AWS s3 buckets as issued by an object-created event via sqs."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Add the ability to delete objects from S3 after processing. I have also added a workaround for an issue with the JRuby autoloader that causes "uninitialized constant `Aws::Client::Errors`" errors.