### PR TITLE
Unescape S3 keys

### DIFF
--- a/lib/logstash/inputs/s3sqs.rb
+++ b/lib/logstash/inputs/s3sqs.rb
@@ -5,6 +5,7 @@ require "logstash/namespace"
 require "logstash/timestamp"
 require "logstash/plugin_mixins/aws_config"
 require "logstash/errors"
+require "cgi/util"
 
 # Get logs from AWS s3 buckets as issued by an object-created event via sqs.
 #
@@ -133,7 +134,7 @@ class LogStash::Inputs::S3SQS < LogStash::Inputs::Threadable
           begin
             response = @s3.get_object(
               bucket: record['s3']['bucket']['name'],
-              key: record['s3']['object']['key']
+              key: CGI.unescape(record['s3']['object']['key'])
             )
           rescue => e
             @logger.warn("issuing :skip_delete on failed download", :bucket => record['s3']['bucket']['name'], :object => record['s3']['object']['key'], :error => e)


### PR DESCRIPTION
We're trying to import files with names like:

`get_offsets_t0/2017-11-26T00:31:33`

These get urlencoded within the SQS event body like:

`"key":"get_offsets_t0/2017-11-26T00%3A31%3A33"`

breaking this plugin. 